### PR TITLE
Add Sphinx directive/roles: "infocard" and "tag(s)"

### DIFF
--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -63,6 +63,8 @@ Head over to the "directives" and "roles" sections to learn about the web elemen
 provided by this collection, and how to use them in your documentation markup.
 
 - [](#gridtable-directive)
+- [](#infocard-directive)
+- [](#tag-role)
 
 Both [reStructuredText] and [Markedly Structured Text] syntax are supported equally well.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,6 +70,14 @@ get_started
 :hidden:
 
 gridtable
+infocard
+```
+
+```{toctree}
+:caption: Roles
+:hidden:
+
+tag
 ```
 
 ```{toctree}
@@ -91,6 +99,20 @@ sandbox
 :link-type: doc
 
 HTML table based on a grid layout, with ergonomic top-down configuration.
+:::
+
+:::{grid-item-card} {octicon}`note` Info card
+:link: infocard
+:link-type: doc
+
+Composite info card container element, to be used as a grid item.
+:::
+
+:::{grid-item-card} {octicon}`plus-circle` Special badges
+:link: tag
+:link-type: doc
+
+Special {bdg-primary}`badges` and other components.
 :::
 
 ::::

--- a/docs/infocard.md
+++ b/docs/infocard.md
@@ -1,0 +1,64 @@
+(infocard-directive)=
+
+# Info Card
+
+
+## About
+
+A composite info card container element, to be used as an item within
+a [grid layout](inv:sd#grids). It provides the Sphinx directive `info-card`.
+
+
+## Details
+
+The info card is a composite element offering a title, description text, and
+both verbose and short tags. It is suitable for authoring pages enumerating
+items with dense information, without the maintenance nightmares of tables.
+
+For a compact notation of the short tag elements, it uses the corresponding
+[](#tag-role) for efficiently rendering [](inv:sd#badges), which is also
+provided by this package.
+
+
+## Synopsis
+
+::::{info-card}
+
+:::{grid-item}
+:columns: 8
+[example.org/beagles](https://example.org/beagles)
+
+A module for collecting votes from beagles, \
+and for consolidating them.
+
+**Author:** C. Schultz, Universal Features Syndicate \
+**Contact:** Los Angeles, CA; <cschultz@peanuts.example.org>
+:::
+
+:::{grid-item}
+:columns: 4
+
+{tags-primary}`foo, bar`
+
+{tags-success}`baz`
+
+{tags-secondary}`qux`
+
+{tags-info}`anything`
+:::
+
+::::
+
+
+## Usage
+````{tab-set-code}
+```{literalinclude} ./snippets/myst/infocard.md
+:language: markdown
+```
+```{literalinclude} ./snippets/rst/infocard.rst
+:language: rst
+```
+````
+
+
+_This page is written in Markedly Structured Text (MyST Markdown)._

--- a/docs/snippets/myst/infocard.md
+++ b/docs/snippets/myst/infocard.md
@@ -1,0 +1,26 @@
+::::{info-card}
+
+:::{grid-item}
+:columns: 8
+[example.org/beagles](https://example.org/beagles)
+
+A module for collecting votes from beagles, \
+and for consolidating them.
+
+**Author:** C. Schultz, Universal Features Syndicate \
+**Contact:** Los Angeles, CA; <cschultz@peanuts.example.org>
+:::
+
+:::{grid-item}
+:columns: 4
+
+{tags-primary}`foo, bar`
+
+{tags-success}`baz`
+
+{tags-secondary}`qux`
+
+{tags-info}`anything`
+:::
+
+::::

--- a/docs/snippets/myst/tag.md
+++ b/docs/snippets/myst/tag.md
@@ -1,0 +1,2 @@
+{tag}`foo, bar`
+{tags}`foo, bar`

--- a/docs/snippets/rst/infocard.rst
+++ b/docs/snippets/rst/infocard.rst
@@ -1,0 +1,23 @@
+.. info-card::
+
+    .. grid-item::
+        :columns: 8
+
+        `example.org/beagles <https://example.org/beagles>`_
+
+        | A module for collecting votes from beagles,
+        | and for consolidating them.
+
+        | **Author:** C. Schultz, Universal Features Syndicate
+        | **Contact:** Los Angeles, CA; <cschultz@peanuts.example.org>
+
+    .. grid-item::
+        :columns: 4
+
+        :tags-primary:`foo, bar`
+
+        :tags-success:`baz`
+
+        :tags-secondary:`qux`
+
+        :tags-info:`anything`

--- a/docs/snippets/rst/tag.rst
+++ b/docs/snippets/rst/tag.rst
@@ -1,0 +1,2 @@
+:tag:`foo, bar`
+:tags:`foo, bar`

--- a/docs/tag.md
+++ b/docs/tag.md
@@ -1,0 +1,170 @@
+(tag-role)=
+
+# `tag(s)` role
+
+
+## About
+
+The `tag` and `tags` roles are shortcuts to the `badge` roles of sphinx{design},
+see [](inv:sd#badges).
+
+
+## Details
+
+The idea is to need less code for defining "tag"-like badges within the
+[](#infocard-directive) element. All of them will use the `outline` option flag
+by default, to give them a corresponding visual appearance.
+
+
+## Synopsis
+
+There is the `{tag}`, and the `{tags}` role. A `{tag}` will render its text content
+1:1 into a single badge element, while `{tags}` will split the text by comma (`,`),
+and renders the outcome using individual badge elements.
+
+
+::::{sd-table}
+:widths: 3 3 3 3
+:row-class: top-border
+
+:::{sd-row}
+```{sd-item} **Description**
+```
+```{sd-item} **Appearance**
+```
+```{sd-item} **MyST syntax**
+```
+```{sd-item} **rST syntax**
+```
+:::
+
+:::{sd-row}
+```{sd-item} Single tag
+```
+```{sd-item}
+{tag}`foo, bar`
+```
+```{sd-item}
+```markdown
+{tag}`foo, bar`
+```
+```{sd-item}
+```restructuredtext
+:tag:`foo, bar`
+```
+:::
+
+:::{sd-row}
+```{sd-item} Multiple tags
+```
+```{sd-item}
+{tags}`foo, bar`
+```
+```{sd-item}
+```markdown
+{tags}`foo, bar`
+```
+```{sd-item}
+```restructuredtext
+:tags:`foo, bar`
+```
+:::
+
+::::
+
+
+## Color variants
+
+All colors of badges are supported, by appending a color label from the list of
+[semantic colors] as a suffix to the role name, like presented below.
+
+::::{sd-table}
+:widths: 3 3 6
+:row-class: top-border
+
+:::{sd-row}
+```{sd-item} **Description**
+```
+```{sd-item} **Appearance**
+```
+```{sd-item} **MyST syntax**
+```
+:::
+
+:::{sd-row}
+```{sd-item} Primary and secondary
+```
+```{sd-item}
+{tags-primary}`foo, bar` \
+{tags-secondary}`foo, bar`
+```
+```{sd-item}
+```markdown
+{tags-primary}`foo, bar` \
+{tags-secondary}`foo, bar`
+```
+:::
+
+:::{sd-row}
+```{sd-item} Admonitions
+```
+```{sd-item}
+{tags-success}`foo, bar` \
+{tags-info}`foo, bar` \
+{tags-warning}`foo, bar` \
+{tags-danger}`foo, bar`
+```
+```{sd-item}
+```markdown
+{tags-success}`foo, bar` \
+{tags-info}`foo, bar` \
+{tags-warning}`foo, bar` \
+{tags-danger}`foo, bar`
+```
+:::
+
+:::{sd-row}
+```{sd-item}
+Light to dark
+```
+```{sd-item}
+{tags-white}`foo, bar` \
+{tags-light}`foo, bar` \
+{tags-muted}`foo, bar` \
+{tags-dark}`foo, bar` \
+{tags-black}`foo, bar`
+```
+```{sd-item}
+```markdown
+{tags-white}`foo, bar` \
+{tags-light}`foo, bar` \
+{tags-muted}`foo, bar` \
+{tags-dark}`foo, bar` \
+{tags-black}`foo, bar`
+```
+:::
+
+::::
+
+````{note}
+While the table above only presents Markdown syntax, reStructuredText syntax is
+also supported.
+
+```{eval-rst}
+:tag-warning:`REVIEW!`
+:tags-primary:`foo, bar`
+```
+
+```restructuredtext
+:tag-warning:`REVIEW!`
+:tags-primary:`foo, bar`
+```
+````
+
+
+---
+
+_This page is written in Markedly Structured Text (MyST Markdown)._
+
+
+[semantic colors]: https://sphinx-design.readthedocs.io/en/latest/css_classes.html#colors

--- a/sphinx_design_elements/compiled/style.css
+++ b/sphinx_design_elements/compiled/style.css
@@ -19,3 +19,12 @@
 .sd-col > .highlight-restructuredtext {
   margin: unset;
 }
+
+
+/* Info card */
+
+/* Fix grid item formatting. */
+.sd-col > div.line-block {
+  margin-top: unset;
+  margin-bottom: unset;
+}

--- a/sphinx_design_elements/extension.py
+++ b/sphinx_design_elements/extension.py
@@ -9,6 +9,8 @@ from sphinx_design.extension import depart_container, visit_container
 
 from . import compiled as static_module
 from .gridtable import setup_gridtable
+from .infocard import setup_infocard
+from .tag import setup_tags
 
 
 def setup_extension(app: Sphinx) -> None:
@@ -21,6 +23,8 @@ def setup_extension(app: Sphinx) -> None:
     app.add_node(nodes.container, override=True, html=(visit_container, depart_container))
 
     setup_gridtable(app)
+    setup_infocard(app)
+    setup_tags(app)
 
 
 def update_css_js(app: Sphinx):

--- a/sphinx_design_elements/infocard.py
+++ b/sphinx_design_elements/infocard.py
@@ -1,0 +1,103 @@
+from typing import Dict, List
+
+from docutils import nodes
+from docutils.statemachine import StringList
+from sphinx.application import Sphinx
+from sphinx.util.docutils import SphinxDirective
+from sphinx_design.cards import CardDirective
+from sphinx_design.shared import create_component, margin_option, padding_option
+
+
+def setup_infocard(app: Sphinx):
+    """
+    Set up the `InfoCardDirective` composite web element.
+    """
+    app.add_directive("info-card", InfoCardDirective)
+
+
+class GridBuilderDirective(SphinxDirective):
+    """
+    Helper functions for the `InfoCardDirective` to create grids and cards.
+    """
+
+    def create_grid(self):
+        """
+        Create a "grid layout" using sphinx-design components.
+        """
+        margin_padding_classes = [margin_option("0")[0], padding_option("0")[0]]
+
+        grid_classes = ["sd-container-fluid", "sd-sphinx-override"]
+        grid_container = create_component(
+            "grid-container",
+            grid_classes
+            + margin_padding_classes
+            + (["sd-border-1"] if "outline" in self.options else [])
+            + self.options.get("class-container", []),
+        )
+        self.set_source_info(grid_container)
+        grid_row = create_component(
+            "grid-row",
+            ["sd-row"]
+            + margin_padding_classes
+            + self.options.get("gutter", [])
+            + (["sd-flex-row-reverse"] if "reverse" in self.options else [])
+            + self.options.get("class-row", []),
+        )
+        self.set_source_info(grid_row)
+        grid_container += grid_row
+        return grid_container, grid_row
+
+    def create_card(self):
+        """
+        Create a sphinx-design "card" component.
+        """
+        # A dummy directive needed to use the CardDirective.
+        dummy = SphinxDirective(
+            name="sdroot",
+            arguments=[],
+            options={},
+            content=StringList(None),
+            lineno=self.lineno,
+            content_offset=self.content_offset,
+            block_text="",
+            state=self.state,
+            state_machine=self.state_machine,
+        )
+        card = CardDirective.create_card(dummy, [], {})
+        self.set_source_info(card)
+        return card
+
+
+class InfoCardDirective(GridBuilderDirective):
+    """
+    A composite info card container element, offering a title, description text, and both
+    verbose and short tags.
+
+    It is suitable for authoring pages enumerating items with dense information, without
+    the maintenance nightmares of tables.
+    """
+
+    has_content = True
+    required_arguments = 0
+    optional_arguments = 1
+    option_spec: Dict[str, str] = {}
+
+    def run(self) -> List[nodes.Node]:
+        # Create a canvas grid.
+        root, canvas = self.create_grid()
+
+        # Create a card, and add it to the canvas.
+        card = self.create_card()
+        canvas += card
+
+        # Create a content grid, and add it to the card.
+        outer, inner = self.create_grid()
+        self.set_source_info(outer)
+        card += outer
+
+        # Parse the node content, assuming grid items, and add them to the content grid.
+        self.state.nested_parse(self.content, self.content_offset, inner)
+        self.set_source_info(inner)
+
+        # Return a reference to the root node.
+        return [root]

--- a/sphinx_design_elements/tag.py
+++ b/sphinx_design_elements/tag.py
@@ -1,0 +1,73 @@
+import typing as t
+
+from docutils import nodes
+from sphinx.application import Sphinx
+from sphinx_design.badges_buttons import BadgeRole, create_bdg_classes
+from sphinx_design.shared import SEMANTIC_COLORS
+
+
+def setup_tags(app: Sphinx) -> None:
+    """
+    Set up the tag(s) shortcut roles.
+
+    Tag shortcut roles are rendering sphinx-design "badge" components
+    using a specific visual appearance.
+    """
+    app.add_role("tag", BadgeRole("primary", outline=True))
+    app.add_role("tags", MultipleBadgeRole("primary", outline=True))
+    for color in SEMANTIC_COLORS:
+        app.add_role(
+            "-".join(("tag", color)),
+            BadgeRole(color, outline=True),
+        )
+        app.add_role(
+            "-".join(("tags", color)),
+            MultipleBadgeRole(color, outline=True),
+        )
+
+
+class MultipleBadgeRole(BadgeRole):
+    """
+    A Sphinx role displaying multiple sphinx-design "badge" components.
+
+    Synopsis MyST:
+
+        {tags-primary}`foo, bar`
+
+    Synopsis rST:
+
+        :tags-primary:`foo, bar`
+    """
+
+    def decode_input_text(self) -> t.List[str]:
+        """
+        Decode input text, splitting by comma.
+        """
+        return list(map(str.strip, self.text.split(",")))
+
+    def run(self) -> t.Tuple[t.List[nodes.Node], t.List[nodes.system_message]]:
+        """
+        Run the role, rendering multiple "badge" nodes.
+        """
+        elements = []
+
+        # Enumerate multiple items.
+        for text in self.decode_input_text():
+            # Add one node per item.
+            node = nodes.inline(
+                self.rawtext,
+                text,
+                classes=create_bdg_classes(self.color, self.outline),
+            )
+            self.set_source_info(node)
+            elements.append(node)
+
+            # Add spacer node.
+            spacer = nodes.inline(" ", " ")
+            elements.append(spacer)
+
+        # Remove last spacer again.
+        if elements:
+            elements.remove(elements[-1])
+
+        return elements, []

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -1,0 +1,109 @@
+"""
+Test the documented snippets run correctly.
+
+Contrary to sphinx-design, this test suite is more relaxed on different
+outcomes between rST and MyST renderings, because, due to the nature of
+composite elements, the outcome of more complex nested nodes is often
+not the same, specifically when using multi-line content or
+cross-references within cell/item contents.
+"""
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from .conftest import SphinxBuilder
+
+SNIPPETS_PATH = Path(__file__).parent.parent / "docs" / "snippets"
+SNIPPETS_GLOB_RST = list((SNIPPETS_PATH / "rst").glob("[!_]*"))
+SNIPPETS_GLOB_MYST = list((SNIPPETS_PATH / "myst").glob("[!_]*"))
+
+
+def write_assets(src_path: Path):
+    """Write additional assets to the src directory."""
+    src_path.joinpath("snippet.py").write_text("a = 1")
+    src_path.joinpath("images").mkdir()
+    src_path.joinpath("images", "ebp-logo.png").touch()
+    src_path.joinpath("images", "particle_background.jpg").touch()
+
+
+@pytest.mark.parametrize(
+    "path",
+    SNIPPETS_GLOB_RST,
+    ids=[path.name[: -len(path.suffix)] for path in SNIPPETS_GLOB_RST],
+)
+def test_snippets_rst_pre(sphinx_builder: Callable[..., SphinxBuilder], path: Path, file_regression):
+    """Test snippets written in RestructuredText (before post-transforms)."""
+    builder = sphinx_builder()
+    content = "Heading\n-------" + "\n\n" + path.read_text(encoding="utf8")
+    builder.src_path.joinpath("index.rst").write_text(content, encoding="utf8")
+    write_assets(builder.src_path)
+    builder.build()
+    pformat = builder.get_doctree("index").pformat()
+    file_regression.check(
+        pformat,
+        basename=f"snippet_rst_pre_{path.name[:-len(path.suffix)]}",
+        extension=".xml",
+        encoding="utf8",
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    SNIPPETS_GLOB_MYST,
+    ids=[path.name[: -len(path.suffix)] for path in SNIPPETS_GLOB_MYST],
+)
+def test_snippets_myst_pre(sphinx_builder: Callable[..., SphinxBuilder], path: Path, file_regression):
+    """Test snippets written in MyST Markdown (before post-transforms)."""
+    builder = sphinx_builder()
+    content = "# Heading" + "\n\n\n" + path.read_text(encoding="utf8")
+    builder.src_path.joinpath("index.md").write_text(content, encoding="utf8")
+    write_assets(builder.src_path)
+    builder.build()
+    file_regression.check(
+        builder.get_doctree("index").pformat(),
+        basename=f"snippet_myst_pre_{path.name[:-len(path.suffix)]}",
+        extension=".xml",
+        encoding="utf8",
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    SNIPPETS_GLOB_RST,
+    ids=[path.name[: -len(path.suffix)] for path in SNIPPETS_GLOB_RST],
+)
+def test_snippets_rst_post(sphinx_builder: Callable[..., SphinxBuilder], path: Path, file_regression):
+    """Test snippets written in RestructuredText (after HTML post-transforms)."""
+    builder = sphinx_builder()
+    content = "Heading\n-------" + "\n\n" + path.read_text(encoding="utf8")
+    builder.src_path.joinpath("index.rst").write_text(content, encoding="utf8")
+    write_assets(builder.src_path)
+    builder.build()
+    pformat = builder.get_doctree("index", post_transforms=True).pformat()
+    file_regression.check(
+        pformat,
+        basename=f"snippet_rst_post_{path.name[:-len(path.suffix)]}",
+        extension=".xml",
+        encoding="utf8",
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    SNIPPETS_GLOB_MYST,
+    ids=[path.name[: -len(path.suffix)] for path in SNIPPETS_GLOB_MYST],
+)
+def test_snippets_myst_post(sphinx_builder: Callable[..., SphinxBuilder], path: Path, file_regression):
+    """Test snippets written in MyST Markdown (after HTML post-transforms)."""
+    builder = sphinx_builder()
+    content = "# Heading" + "\n\n\n" + path.read_text(encoding="utf8")
+    builder.src_path.joinpath("index.md").write_text(content, encoding="utf8")
+    write_assets(builder.src_path)
+    builder.build()
+    file_regression.check(
+        builder.get_doctree("index", post_transforms=True).pformat(),
+        basename=f"snippet_myst_post_{path.name[:-len(path.suffix)]}",
+        extension=".xml",
+        encoding="utf8",
+    )

--- a/tests/test_snippets/snippet_myst_post_infocard.xml
+++ b/tests/test_snippets/snippet_myst_post_infocard.xml
@@ -1,0 +1,51 @@
+<document source="index">
+    <section ids="heading" names="heading">
+        <title>
+            Heading
+        <container classes="sd-container-fluid sd-sphinx-override sd-m-0 sd-p-0" design_component="grid-container" is_div="True">
+            <container classes="sd-row sd-m-0 sd-p-0" design_component="grid-row" is_div="True">
+                <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm" design_component="card" is_div="True">
+                    <container classes="sd-card-body" design_component="card-body" is_div="True">
+                    <container classes="sd-container-fluid sd-sphinx-override sd-m-0 sd-p-0" design_component="grid-container" is_div="True">
+                        <container classes="sd-row sd-m-0 sd-p-0" design_component="grid-row" is_div="True">
+                            <container classes="sd-col sd-d-flex-column sd-col-8 sd-col-xs-8 sd-col-sm-8 sd-col-md-8 sd-col-lg-8" design_component="grid-item" is_div="True">
+                                <paragraph>
+                                    <reference refuri="https://example.org/beagles">
+                                        example.org/beagles
+                                <paragraph>
+                                    A module for collecting votes from beagles, 
+                                    <raw format="html" xml:space="preserve">
+                                        <br />
+                                    <raw format="latex" xml:space="preserve">
+                                        \\
+                                    and for consolidating them.
+                                <paragraph>
+                                    <strong>
+                                        Author:
+                                     C. Schultz, Universal Features Syndicate 
+                                    <raw format="html" xml:space="preserve">
+                                        <br />
+                                    <raw format="latex" xml:space="preserve">
+                                        \\
+                                    <strong>
+                                        Contact:
+                                     Los Angeles, CA; 
+                                    <reference refuri="mailto:cschultz@peanuts.example.org">
+                                        cschultz@peanuts.example.org
+                            <container classes="sd-col sd-d-flex-column sd-col-4 sd-col-xs-4 sd-col-sm-4 sd-col-md-4 sd-col-lg-4" design_component="grid-item" is_div="True">
+                                <paragraph>
+                                    <inline classes="sd-sphinx-override sd-badge sd-outline-primary sd-text-primary">
+                                        foo
+                                    <inline>
+                                         
+                                    <inline classes="sd-sphinx-override sd-badge sd-outline-primary sd-text-primary">
+                                        bar
+                                <paragraph>
+                                    <inline classes="sd-sphinx-override sd-badge sd-outline-success sd-text-success">
+                                        baz
+                                <paragraph>
+                                    <inline classes="sd-sphinx-override sd-badge sd-outline-secondary sd-text-secondary">
+                                        qux
+                                <paragraph>
+                                    <inline classes="sd-sphinx-override sd-badge sd-outline-info sd-text-info">
+                                        anything

--- a/tests/test_snippets/snippet_myst_post_tag.xml
+++ b/tests/test_snippets/snippet_myst_post_tag.xml
@@ -1,0 +1,14 @@
+<document source="index">
+    <section ids="heading" names="heading">
+        <title>
+            Heading
+        <paragraph>
+            <inline classes="sd-sphinx-override sd-badge sd-outline-primary sd-text-primary">
+                foo, bar
+            
+            <inline classes="sd-sphinx-override sd-badge sd-outline-primary sd-text-primary">
+                foo
+            <inline>
+                 
+            <inline classes="sd-sphinx-override sd-badge sd-outline-primary sd-text-primary">
+                bar

--- a/tests/test_snippets/snippet_myst_pre_infocard.xml
+++ b/tests/test_snippets/snippet_myst_pre_infocard.xml
@@ -1,0 +1,51 @@
+<document source="index">
+    <section ids="heading" names="heading">
+        <title>
+            Heading
+        <container classes="sd-container-fluid sd-sphinx-override sd-m-0 sd-p-0" design_component="grid-container" is_div="True">
+            <container classes="sd-row sd-m-0 sd-p-0" design_component="grid-row" is_div="True">
+                <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm" design_component="card" is_div="True">
+                    <container classes="sd-card-body" design_component="card-body" is_div="True">
+                    <container classes="sd-container-fluid sd-sphinx-override sd-m-0 sd-p-0" design_component="grid-container" is_div="True">
+                        <container classes="sd-row sd-m-0 sd-p-0" design_component="grid-row" is_div="True">
+                            <container classes="sd-col sd-d-flex-column sd-col-8 sd-col-xs-8 sd-col-sm-8 sd-col-md-8 sd-col-lg-8" design_component="grid-item" is_div="True">
+                                <paragraph>
+                                    <reference refuri="https://example.org/beagles">
+                                        example.org/beagles
+                                <paragraph>
+                                    A module for collecting votes from beagles, 
+                                    <raw format="html" xml:space="preserve">
+                                        <br />
+                                    <raw format="latex" xml:space="preserve">
+                                        \\
+                                    and for consolidating them.
+                                <paragraph>
+                                    <strong>
+                                        Author:
+                                     C. Schultz, Universal Features Syndicate 
+                                    <raw format="html" xml:space="preserve">
+                                        <br />
+                                    <raw format="latex" xml:space="preserve">
+                                        \\
+                                    <strong>
+                                        Contact:
+                                     Los Angeles, CA; 
+                                    <reference refuri="mailto:cschultz@peanuts.example.org">
+                                        cschultz@peanuts.example.org
+                            <container classes="sd-col sd-d-flex-column sd-col-4 sd-col-xs-4 sd-col-sm-4 sd-col-md-4 sd-col-lg-4" design_component="grid-item" is_div="True">
+                                <paragraph>
+                                    <inline classes="sd-sphinx-override sd-badge sd-outline-primary sd-text-primary">
+                                        foo
+                                    <inline>
+                                         
+                                    <inline classes="sd-sphinx-override sd-badge sd-outline-primary sd-text-primary">
+                                        bar
+                                <paragraph>
+                                    <inline classes="sd-sphinx-override sd-badge sd-outline-success sd-text-success">
+                                        baz
+                                <paragraph>
+                                    <inline classes="sd-sphinx-override sd-badge sd-outline-secondary sd-text-secondary">
+                                        qux
+                                <paragraph>
+                                    <inline classes="sd-sphinx-override sd-badge sd-outline-info sd-text-info">
+                                        anything

--- a/tests/test_snippets/snippet_myst_pre_tag.xml
+++ b/tests/test_snippets/snippet_myst_pre_tag.xml
@@ -1,0 +1,14 @@
+<document source="index">
+    <section ids="heading" names="heading">
+        <title>
+            Heading
+        <paragraph>
+            <inline classes="sd-sphinx-override sd-badge sd-outline-primary sd-text-primary">
+                foo, bar
+            
+            <inline classes="sd-sphinx-override sd-badge sd-outline-primary sd-text-primary">
+                foo
+            <inline>
+                 
+            <inline classes="sd-sphinx-override sd-badge sd-outline-primary sd-text-primary">
+                bar

--- a/tests/test_snippets/snippet_rst_post_infocard.xml
+++ b/tests/test_snippets/snippet_rst_post_infocard.xml
@@ -1,0 +1,49 @@
+<document source="index">
+    <section ids="heading" names="heading">
+        <title>
+            Heading
+        <container classes="sd-container-fluid sd-sphinx-override sd-m-0 sd-p-0" design_component="grid-container" is_div="True">
+            <container classes="sd-row sd-m-0 sd-p-0" design_component="grid-row" is_div="True">
+                <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm" design_component="card" is_div="True">
+                    <container classes="sd-card-body" design_component="card-body" is_div="True">
+                    <container classes="sd-container-fluid sd-sphinx-override sd-m-0 sd-p-0" design_component="grid-container" is_div="True">
+                        <container classes="sd-row sd-m-0 sd-p-0" design_component="grid-row" is_div="True">
+                            <container classes="sd-col sd-d-flex-column sd-col-8 sd-col-xs-8 sd-col-sm-8 sd-col-md-8 sd-col-lg-8" design_component="grid-item" is_div="True">
+                                <paragraph>
+                                    <reference name="example.org/beagles" refuri="https://example.org/beagles">
+                                        example.org/beagles
+                                    <target ids="example-org-beagles" names="example.org/beagles" refuri="https://example.org/beagles">
+                                <line_block>
+                                    <line>
+                                        A module for collecting votes from beagles,
+                                    <line>
+                                        and for consolidating them.
+                                <line_block>
+                                    <line>
+                                        <strong>
+                                            Author:
+                                         C. Schultz, Universal Features Syndicate
+                                    <line>
+                                        <strong>
+                                            Contact:
+                                         Los Angeles, CA; <
+                                        <reference refuri="mailto:cschultz@peanuts.example.org">
+                                            cschultz@peanuts.example.org
+                                        >
+                            <container classes="sd-col sd-d-flex-column sd-col-4 sd-col-xs-4 sd-col-sm-4 sd-col-md-4 sd-col-lg-4" design_component="grid-item" is_div="True">
+                                <paragraph>
+                                    <inline classes="sd-sphinx-override sd-badge sd-outline-primary sd-text-primary">
+                                        foo
+                                    <inline>
+                                         
+                                    <inline classes="sd-sphinx-override sd-badge sd-outline-primary sd-text-primary">
+                                        bar
+                                <paragraph>
+                                    <inline classes="sd-sphinx-override sd-badge sd-outline-success sd-text-success">
+                                        baz
+                                <paragraph>
+                                    <inline classes="sd-sphinx-override sd-badge sd-outline-secondary sd-text-secondary">
+                                        qux
+                                <paragraph>
+                                    <inline classes="sd-sphinx-override sd-badge sd-outline-info sd-text-info">
+                                        anything

--- a/tests/test_snippets/snippet_rst_post_tag.xml
+++ b/tests/test_snippets/snippet_rst_post_tag.xml
@@ -1,0 +1,14 @@
+<document source="index">
+    <section ids="heading" names="heading">
+        <title>
+            Heading
+        <paragraph>
+            <inline classes="sd-sphinx-override sd-badge sd-outline-primary sd-text-primary">
+                foo, bar
+            
+            <inline classes="sd-sphinx-override sd-badge sd-outline-primary sd-text-primary">
+                foo
+            <inline>
+                 
+            <inline classes="sd-sphinx-override sd-badge sd-outline-primary sd-text-primary">
+                bar

--- a/tests/test_snippets/snippet_rst_pre_infocard.xml
+++ b/tests/test_snippets/snippet_rst_pre_infocard.xml
@@ -1,0 +1,49 @@
+<document source="index">
+    <section ids="heading" names="heading">
+        <title>
+            Heading
+        <container classes="sd-container-fluid sd-sphinx-override sd-m-0 sd-p-0" design_component="grid-container" is_div="True">
+            <container classes="sd-row sd-m-0 sd-p-0" design_component="grid-row" is_div="True">
+                <container classes="sd-card sd-sphinx-override sd-mb-3 sd-shadow-sm" design_component="card" is_div="True">
+                    <container classes="sd-card-body" design_component="card-body" is_div="True">
+                    <container classes="sd-container-fluid sd-sphinx-override sd-m-0 sd-p-0" design_component="grid-container" is_div="True">
+                        <container classes="sd-row sd-m-0 sd-p-0" design_component="grid-row" is_div="True">
+                            <container classes="sd-col sd-d-flex-column sd-col-8 sd-col-xs-8 sd-col-sm-8 sd-col-md-8 sd-col-lg-8" design_component="grid-item" is_div="True">
+                                <paragraph>
+                                    <reference name="example.org/beagles" refuri="https://example.org/beagles">
+                                        example.org/beagles
+                                    <target ids="example-org-beagles" names="example.org/beagles" refuri="https://example.org/beagles">
+                                <line_block>
+                                    <line>
+                                        A module for collecting votes from beagles,
+                                    <line>
+                                        and for consolidating them.
+                                <line_block>
+                                    <line>
+                                        <strong>
+                                            Author:
+                                         C. Schultz, Universal Features Syndicate
+                                    <line>
+                                        <strong>
+                                            Contact:
+                                         Los Angeles, CA; <
+                                        <reference refuri="mailto:cschultz@peanuts.example.org">
+                                            cschultz@peanuts.example.org
+                                        >
+                            <container classes="sd-col sd-d-flex-column sd-col-4 sd-col-xs-4 sd-col-sm-4 sd-col-md-4 sd-col-lg-4" design_component="grid-item" is_div="True">
+                                <paragraph>
+                                    <inline classes="sd-sphinx-override sd-badge sd-outline-primary sd-text-primary">
+                                        foo
+                                    <inline>
+                                         
+                                    <inline classes="sd-sphinx-override sd-badge sd-outline-primary sd-text-primary">
+                                        bar
+                                <paragraph>
+                                    <inline classes="sd-sphinx-override sd-badge sd-outline-success sd-text-success">
+                                        baz
+                                <paragraph>
+                                    <inline classes="sd-sphinx-override sd-badge sd-outline-secondary sd-text-secondary">
+                                        qux
+                                <paragraph>
+                                    <inline classes="sd-sphinx-override sd-badge sd-outline-info sd-text-info">
+                                        anything

--- a/tests/test_snippets/snippet_rst_pre_tag.xml
+++ b/tests/test_snippets/snippet_rst_pre_tag.xml
@@ -1,0 +1,14 @@
+<document source="index">
+    <section ids="heading" names="heading">
+        <title>
+            Heading
+        <paragraph>
+            <inline classes="sd-sphinx-override sd-badge sd-outline-primary sd-text-primary">
+                foo, bar
+            
+            <inline classes="sd-sphinx-override sd-badge sd-outline-primary sd-text-primary">
+                foo
+            <inline>
+                 
+            <inline classes="sd-sphinx-override sd-badge sd-outline-primary sd-text-primary">
+                bar


### PR DESCRIPTION
## About
Add Sphinx directive/roles: "infocard" and "tag(s)".

## Appearance
![image](https://github.com/panodata/sphinx-design-elements/assets/453543/645a63e9-19f1-453c-8b3b-cc3c69ca7044)

## Details
A composite web element offering a title, description text, and both
verbose and short tags. It is suitable for authoring pages enumerating
items with dense information, without the maintenance nightmares of
tables.

## References
- https://hiveeyes.org/docs/arduino/firmware/overview.html
- https://kotori.readthedocs.io/en/latest/integration/