### PR TITLE
More examples and documentation copy-editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,20 @@ high-level elements on top.
 In order to learn how to set up the project in development mode, please visit the
 [development documentation].
 
+## Acknowledgements
+
+Kudos to [Chris Sewell] and all contributors for conceiving and maintaining
+[MyST Parser] and [sphinx-design].
+
 
 
 [Changelog]: https://github.com/panodata/sphinx-design-elements/blob/main/CHANGES.md
+[Chris Sewell]: https://github.com/chrisjsewell
 [development documentation]: https://sphinx-design-elements.readthedocs.io/en/latest/sandbox.html
 [Documentation]: https://sphinx-design-elements.readthedocs.io/
 [Issues]: https://github.com/panodata/sphinx-design-elements/issues
 [License]: https://github.com/panodata/sphinx-design-elements/blob/main/LICENSE
+[MyST Parser]: https://myst-parser.readthedocs.io/
 [PyPI]: https://pypi.org/project/sphinx-design-elements/
 [Source code]: https://github.com/panodata/sphinx-design-elements
 [sphinx-design]: https://sphinx-design.readthedocs.io/

--- a/docs/css_classes.md
+++ b/docs/css_classes.md
@@ -32,4 +32,41 @@ Larger text.
 :::
 
 
+## Table styling
+
+The `.{top,bottom}-border` CSS classes adjust the `border-{top,bottom}-{width,style,color}`
+CSS attributes. They are meant to be applied to rows in a [](gridtable-directive) by using
+its `:row-class:` directive option.
+
+:::::{card}
+::::{sd-table}
+:widths: 3 9
+:row-class: top-border
+
+:::{sd-row}
+```{sd-item} **What**
+```
+```{sd-item} **Description**
+```
+:::
+:::{sd-row}
+```{sd-item} Fox
+```
+```{sd-item}
+The quick brown fox jumps
+over the lazy dog.
+```
+:::
+:::{sd-row}
+```{sd-item} Franz
+```
+```{sd-item}
+Franz jagt im komplett verwahrlosten
+Taxi quer durch Bayern.
+```
+:::
+
+::::
+:::::
+
 [`compiled/style.css`]: https://github.com/panodata/sphinx-design-elements/blob/main/sphinx_design_elements/compiled/style.css

--- a/docs/css_classes.md
+++ b/docs/css_classes.md
@@ -1,0 +1,35 @@
+(css-classes)=
+
+# CSS Classes
+
+Additionally to [sphinx{design}](inv:sd#index)'s [](inv:sd#css_classes),
+this package provides a few more CSS classes, mostly serving as convenience
+shortcuts.
+See [`compiled/style.css`] for inspecting the whole CSS rule file.
+
+
+## Font sizes
+
+The `.text-{small,smaller,medium,larger,large}` CSS classes exclusively adjust the
+`font-size` CSS attribute. They can be used anywhere.
+
+:::{card}
+```{div} text-small
+Small text.
+```
+```{div} text-smaller
+Smaller text.
+```
+```{div} text-medium
+Medium text.
+```
+```{div} text-large
+Large text.
+```
+```{div} text-larger
+Larger text.
+```
+:::
+
+
+[`compiled/style.css`]: https://github.com/panodata/sphinx-design-elements/blob/main/sphinx_design_elements/compiled/style.css

--- a/docs/gridtable.md
+++ b/docs/gridtable.md
@@ -29,6 +29,8 @@ elsewhere.
 
 Basic table, two columns, no formatting.
 
+:::::{div} sd-shadow-md
+
 ::::{sd-table}
 :widths: 3 9
 
@@ -57,6 +59,7 @@ Taxi quer durch Bayern.
 :::
 
 ::::
+:::::
 
 
 ## Usage

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,6 +81,13 @@ tag
 ```
 
 ```{toctree}
+:caption: Styling
+:hidden:
+
+css_classes
+```
+
+```{toctree}
 :caption: Development
 :hidden:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ Get Started
 
 ::::::
 
-Building upon sphinx{design}
+Building upon sphinx{design} and Flexbox
 : [sphinx-design] is a Sphinx extension for designing beautiful, screen-size
   responsive web-components. It is inspired by the [Bootstrap], [Material Design],
   and [Material-UI] design frameworks, and uses [CSS Flexible Box Layout], commonly

--- a/docs/infocard.md
+++ b/docs/infocard.md
@@ -66,6 +66,46 @@ badges](inv:sd#badges) with a special appearance.
 ````
 
 
+## More examples
+
+:::::{info-card}
+
+::::{grid-item}
+:columns: 8
+:class: sd-align-major-spaced
+#### Curated picture of the day
+
+A mountain goat with long horns standing on a grassy hill.
+
+:::{div} text-small
+**Author:** Jaromír Kalina, [@jkalinaofficial](https://unsplash.com/@jkalinaofficial) \
+**Contact:** Czech Republic, <https://jkalina.carrd.co/> \
+**Exposé:** https://unsplash.com/photos/spdQ1dVuIHw \
+**Source:** [Unsplash -- The internet’s source for visuals](https://unsplash.com/)
+:::
+::::
+
+::::{grid-item}
+:columns: 4
+
+[![](https://unsplash.com/photos/spdQ1dVuIHw/download?ixid=M3wxMjA3fDB8MXxhbGx8fHx8fHx8fHwxNjg5Nzg4MTEzfA&force=true&w=640)](https://unsplash.com/photos/spdQ1dVuIHw)
+::::
+
+:::::
+
+:::{note}
+Did you ever ask yourself how to [align items in a flex container], and how to control
+all those details within Sphinx documentation markup? The documentation about
+[using sphinx{design} CSS classes to align flexbox items] has all the answers.
+In this case, the items within the left content column are aligned "spaced", to fill the
+full major axis, using the `sd-align-major-spaced` CSS class.
+:::
+
+
 ---
 
 _This page is written in Markedly Structured Text (MyST Markdown)._
+
+
+[align items in a flex container]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flexible_box_layout/Aligning_items_in_a_flex_container
+[using sphinx{design} CSS classes to align flexbox items]: https://sphinx-design.readthedocs.io/en/latest/css_classes.html#display

--- a/sphinx_design_elements/compiled/style.css
+++ b/sphinx_design_elements/compiled/style.css
@@ -1,6 +1,37 @@
-/* Grid table */
+/**
+ * Appearance shortcuts.
+ */
 
-/* Beautiful light-weight table outline flavor. */
+
+/* General */
+
+/* Very small text size */
+.text-small {
+  font-size: small;
+}
+
+/* Smaller text size */
+.text-smaller {
+  font-size: smaller;
+}
+
+/* Medium text size */
+.text-medium {
+  font-size: medium;
+}
+
+/* Large text size */
+.text-large {
+  font-size: large;
+}
+
+/* Very large text size */
+.text-larger {
+  font-size: larger;
+}
+
+
+/* Grid table: Light-weight table-row outline styling. */
 .top-border {
   border-top-width: thin;
   border-top-style: solid;
@@ -12,7 +43,12 @@
   border-top-color: lightgray;
 }
 
-/* Remove margins of child elements inside table items. */
+
+/**
+ * Appearance bugfixes.
+ */
+
+/* Grid table: Fix margins of child elements inside table items. */
 .sd-col > .highlight-markdown {
   margin: unset;
 }
@@ -20,10 +56,7 @@
   margin: unset;
 }
 
-
-/* Info card */
-
-/* Fix grid item formatting. */
+/* Info card: Fix grid item formatting. */
 .sd-col > div.line-block {
   margin-top: unset;
   margin-bottom: unset;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,12 @@ pytest_plugins = "sphinx.testing.fixtures"
 
 
 class SphinxBuilder:
+    """
+    Sphinx builder fixture implementation for pytest.
+
+    TODO: Currently copied from `sphinx-design`. Maybe import from there instead?
+    """
+
     def __init__(self, app: SphinxTestApp, src_path: Path):
         self.app = app
         self._src_path = src_path
@@ -59,6 +65,12 @@ class SphinxBuilder:
 
 @pytest.fixture()
 def sphinx_builder(tmp_path: Path, make_app, monkeypatch):
+    """
+    Sphinx builder fixture entrypoint for pytest.
+
+    TODO: Currently copied from `sphinx-design`. Maybe import from there instead?
+    """
+
     def _create_project(buildername: str = "html", conf_kwargs: Optional[Dict[str, Any]] = None):
         src_path = tmp_path / "srcdir"
         src_path.mkdir()


### PR DESCRIPTION
- CSS Classes: Add `.text-{small,smaller,medium,larger,large}` classes.
- Documentation: Add more example presentations for infocard and css.
- Documentation: This and that.