### PR TITLE
Add helper CSS for dropdown elements that should exclusively open

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+- For dropdown elements that should exclusively open when toggled,
+  add a `dropdown-group` CSS class
+
 ## v0.1.0 - 2023-07-19
 
 - Add "grid table" element, using directives `sd-table`, `sd-row`, `sd-item`

--- a/docs/dropdown-group.md
+++ b/docs/dropdown-group.md
@@ -1,0 +1,49 @@
+# Dropdown Group
+
+
+## About
+
+This is an extension to [sphinx-design dropdowns], intending to implement a
+similar behavior like [using CSS `toggle-group` to group exclusive toggles].
+
+If you have multiple dropdown elements, you can group them together, in order
+to make only one toggle from the group active at a time, effectively defining
+exclusive dropdowns.
+
+This is similar to how HTML radio buttons behave, where two buttons cannot be
+checked at the same time.
+
+
+## Usage
+
+In order define a group of multiple dropdown elements that should exclusively
+open when toggled, wrap them into a container element using the `dropdown-group`
+class.
+
+````{tab-set-code}
+```{literalinclude} ./snippets/myst/dropdown-group.md
+:language: markdown
+```
+```{literalinclude} ./snippets/rst/dropdown-group.rst
+:language: rst
+```
+````
+
+
+## Example
+
+::::{div} dropdown-group
+
+:::{dropdown} Dropdown A
+Dropdown content A
+:::
+
+:::{dropdown} Dropdown B
+Dropdown content B
+:::
+
+::::
+
+
+[sphinx-design dropdowns]: https://sphinx-design.readthedocs.io/en/latest/dropdowns.html
+[using CSS `toggle-group` to group exclusive toggles]: https://blog.logrocket.com/advanced-guide-css-toggle-pseudo-class/#using-toggle-group-exclusive-toggles

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,6 +87,7 @@ tag
 :hidden:
 
 css_classes
+dropdown-group
 ```
 
 ```{toctree}

--- a/docs/snippets/myst/dropdown-group.md
+++ b/docs/snippets/myst/dropdown-group.md
@@ -1,0 +1,11 @@
+::::{div} dropdown-group
+
+:::{dropdown} Dropdown A
+Dropdown content A
+:::
+
+:::{dropdown} Dropdown B
+Dropdown content B
+:::
+
+::::

--- a/docs/snippets/rst/dropdown-group.rst
+++ b/docs/snippets/rst/dropdown-group.rst
@@ -1,0 +1,9 @@
+.. div:: dropdown-group
+
+    .. dropdown:: Dropdown A
+
+        Dropdown content A
+
+    .. dropdown:: Dropdown B
+
+        Dropdown content B

--- a/sphinx_design_elements/dropdown_group.py
+++ b/sphinx_design_elements/dropdown_group.py
@@ -1,0 +1,29 @@
+from sphinx.application import Sphinx
+
+
+def setup_dropdown_group(app: Sphinx):
+    """
+    Add JavaScript for defining exclusive dropdown elements using the `dropdown-group` class.
+    """
+    dropdown_js = """
+
+    // Select all relevant detail elements nested within container elements using the `dropdown-group` class.
+    const dropdown_details = document.querySelectorAll(".dropdown-group details");
+
+    // Add event listener for special toggling.
+    dropdown_details.forEach((details) => {
+      details.addEventListener("toggle", toggleOpenGroup);
+    });
+
+    // When toggling elements, exclusively open one element, and close all others.
+    function toggleOpenGroup(e) {
+      if (this.open) {
+        dropdown_details.forEach((details) => {
+          if (details != this && details.open) {
+            details.open = false;
+          }
+        });
+      }
+    }
+    """
+    app.add_js_file(None, body=dropdown_js)

--- a/sphinx_design_elements/extension.py
+++ b/sphinx_design_elements/extension.py
@@ -8,6 +8,7 @@ from sphinx.environment import BuildEnvironment
 from sphinx_design.extension import depart_container, visit_container
 
 from . import compiled as static_module
+from .dropdown_group import setup_dropdown_group
 from .gridtable import setup_gridtable
 from .infocard import setup_infocard
 from .tag import setup_tags
@@ -25,6 +26,7 @@ def setup_extension(app: Sphinx) -> None:
     setup_gridtable(app)
     setup_infocard(app)
     setup_tags(app)
+    setup_dropdown_group(app)
 
 
 def update_css_js(app: Sphinx):

--- a/tests/test_snippets/snippet_myst_post_dropdown-group.xml
+++ b/tests/test_snippets/snippet_myst_post_dropdown-group.xml
@@ -1,0 +1,29 @@
+<document source="index" translation_progress="{'total': 0, 'translated': 0}">
+    <section ids="heading" names="heading">
+        <title>
+            Heading
+        <container classes="dropdown-group" design_component="div" is_div="True">
+            <dropdown_main classes="sd-sphinx-override sd-dropdown sd-card sd-mb-3" opened="False">
+                <dropdown_title classes="sd-summary-title sd-card-header">
+                    Dropdown A
+                    <container classes="sd-summary-down" design_component="dropdown-closed-marker" is_div="True">
+                        <raw format="html" xml:space="preserve">
+                            <svg version="1.1" width="1.5em" height="1.5em" class="sd-octicon sd-octicon-chevron-down" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" d="M5.22 8.72a.75.75 0 000 1.06l6.25 6.25a.75.75 0 001.06 0l6.25-6.25a.75.75 0 00-1.06-1.06L12 14.44 6.28 8.72a.75.75 0 00-1.06 0z"></path></svg>
+                    <container classes="sd-summary-up" design_component="dropdown-open-marker" is_div="True">
+                        <raw format="html" xml:space="preserve">
+                            <svg version="1.1" width="1.5em" height="1.5em" class="sd-octicon sd-octicon-chevron-up" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" d="M18.78 15.28a.75.75 0 000-1.06l-6.25-6.25a.75.75 0 00-1.06 0l-6.25 6.25a.75.75 0 101.06 1.06L12 9.56l5.72 5.72a.75.75 0 001.06 0z"></path></svg>
+                <container classes="sd-summary-content sd-card-body" design_component="dropdown-body" is_div="True">
+                    <paragraph classes="sd-card-text">
+                        Dropdown content A
+            <dropdown_main classes="sd-sphinx-override sd-dropdown sd-card sd-mb-3" opened="False">
+                <dropdown_title classes="sd-summary-title sd-card-header">
+                    Dropdown B
+                    <container classes="sd-summary-down" design_component="dropdown-closed-marker" is_div="True">
+                        <raw format="html" xml:space="preserve">
+                            <svg version="1.1" width="1.5em" height="1.5em" class="sd-octicon sd-octicon-chevron-down" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" d="M5.22 8.72a.75.75 0 000 1.06l6.25 6.25a.75.75 0 001.06 0l6.25-6.25a.75.75 0 00-1.06-1.06L12 14.44 6.28 8.72a.75.75 0 00-1.06 0z"></path></svg>
+                    <container classes="sd-summary-up" design_component="dropdown-open-marker" is_div="True">
+                        <raw format="html" xml:space="preserve">
+                            <svg version="1.1" width="1.5em" height="1.5em" class="sd-octicon sd-octicon-chevron-up" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" d="M18.78 15.28a.75.75 0 000-1.06l-6.25-6.25a.75.75 0 00-1.06 0l-6.25 6.25a.75.75 0 101.06 1.06L12 9.56l5.72 5.72a.75.75 0 001.06 0z"></path></svg>
+                <container classes="sd-summary-content sd-card-body" design_component="dropdown-body" is_div="True">
+                    <paragraph classes="sd-card-text">
+                        Dropdown content B

--- a/tests/test_snippets/snippet_myst_pre_dropdown-group.xml
+++ b/tests/test_snippets/snippet_myst_pre_dropdown-group.xml
@@ -1,0 +1,15 @@
+<document source="index" translation_progress="{'total': 0, 'translated': 0}">
+    <section ids="heading" names="heading">
+        <title>
+            Heading
+        <container classes="dropdown-group" design_component="div" is_div="True">
+            <container body_classes="" container_classes="sd-mb-3" design_component="dropdown" has_title="True" icon="True" is_div="True" opened="False" title_classes="" type="dropdown">
+                <rubric>
+                    Dropdown A
+                <paragraph>
+                    Dropdown content A
+            <container body_classes="" container_classes="sd-mb-3" design_component="dropdown" has_title="True" icon="True" is_div="True" opened="False" title_classes="" type="dropdown">
+                <rubric>
+                    Dropdown B
+                <paragraph>
+                    Dropdown content B

--- a/tests/test_snippets/snippet_rst_post_dropdown-group.xml
+++ b/tests/test_snippets/snippet_rst_post_dropdown-group.xml
@@ -1,0 +1,29 @@
+<document source="index" translation_progress="{'total': 0, 'translated': 0}">
+    <section ids="heading" names="heading">
+        <title>
+            Heading
+        <container classes="dropdown-group" design_component="div" is_div="True">
+            <dropdown_main classes="sd-sphinx-override sd-dropdown sd-card sd-mb-3" opened="False">
+                <dropdown_title classes="sd-summary-title sd-card-header">
+                    Dropdown A
+                    <container classes="sd-summary-down" design_component="dropdown-closed-marker" is_div="True">
+                        <raw format="html" xml:space="preserve">
+                            <svg version="1.1" width="1.5em" height="1.5em" class="sd-octicon sd-octicon-chevron-down" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" d="M5.22 8.72a.75.75 0 000 1.06l6.25 6.25a.75.75 0 001.06 0l6.25-6.25a.75.75 0 00-1.06-1.06L12 14.44 6.28 8.72a.75.75 0 00-1.06 0z"></path></svg>
+                    <container classes="sd-summary-up" design_component="dropdown-open-marker" is_div="True">
+                        <raw format="html" xml:space="preserve">
+                            <svg version="1.1" width="1.5em" height="1.5em" class="sd-octicon sd-octicon-chevron-up" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" d="M18.78 15.28a.75.75 0 000-1.06l-6.25-6.25a.75.75 0 00-1.06 0l-6.25 6.25a.75.75 0 101.06 1.06L12 9.56l5.72 5.72a.75.75 0 001.06 0z"></path></svg>
+                <container classes="sd-summary-content sd-card-body" design_component="dropdown-body" is_div="True">
+                    <paragraph classes="sd-card-text">
+                        Dropdown content A
+            <dropdown_main classes="sd-sphinx-override sd-dropdown sd-card sd-mb-3" opened="False">
+                <dropdown_title classes="sd-summary-title sd-card-header">
+                    Dropdown B
+                    <container classes="sd-summary-down" design_component="dropdown-closed-marker" is_div="True">
+                        <raw format="html" xml:space="preserve">
+                            <svg version="1.1" width="1.5em" height="1.5em" class="sd-octicon sd-octicon-chevron-down" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" d="M5.22 8.72a.75.75 0 000 1.06l6.25 6.25a.75.75 0 001.06 0l6.25-6.25a.75.75 0 00-1.06-1.06L12 14.44 6.28 8.72a.75.75 0 00-1.06 0z"></path></svg>
+                    <container classes="sd-summary-up" design_component="dropdown-open-marker" is_div="True">
+                        <raw format="html" xml:space="preserve">
+                            <svg version="1.1" width="1.5em" height="1.5em" class="sd-octicon sd-octicon-chevron-up" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" d="M18.78 15.28a.75.75 0 000-1.06l-6.25-6.25a.75.75 0 00-1.06 0l-6.25 6.25a.75.75 0 101.06 1.06L12 9.56l5.72 5.72a.75.75 0 001.06 0z"></path></svg>
+                <container classes="sd-summary-content sd-card-body" design_component="dropdown-body" is_div="True">
+                    <paragraph classes="sd-card-text">
+                        Dropdown content B

--- a/tests/test_snippets/snippet_rst_pre_dropdown-group.xml
+++ b/tests/test_snippets/snippet_rst_pre_dropdown-group.xml
@@ -1,0 +1,15 @@
+<document source="index" translation_progress="{'total': 0, 'translated': 0}">
+    <section ids="heading" names="heading">
+        <title>
+            Heading
+        <container classes="dropdown-group" design_component="div" is_div="True">
+            <container body_classes="" container_classes="sd-mb-3" design_component="dropdown" has_title="True" icon="True" is_div="True" opened="False" title_classes="" type="dropdown">
+                <rubric>
+                    Dropdown A
+                <paragraph>
+                    Dropdown content A
+            <container body_classes="" container_classes="sd-mb-3" design_component="dropdown" has_title="True" icon="True" is_div="True" opened="False" title_classes="" type="dropdown">
+                <rubric>
+                    Dropdown B
+                <paragraph>
+                    Dropdown content B


### PR DESCRIPTION
## About

This is an extension to [sphinx-design dropdowns](https://sphinx-design.readthedocs.io/en/latest/dropdowns.html), intending to implement a similar behavior like [using CSS toggle-group to group exclusive toggles](https://blog.logrocket.com/advanced-guide-css-toggle-pseudo-class/#using-toggle-group-exclusive-toggles).

If you have multiple dropdown elements, you can group them together, in order to make only one toggle from the group active at a time, effectively defining exclusive dropdowns.

This is similar to how HTML radio buttons behave, where two buttons cannot be checked at the same time.

## Details

This patch aims to generalize the implementation from https://github.com/crate/crate-docs-theme/pull/417, and, at the same time, constrain it a bit to be able to apply it only to specific dropdown elements. Thanks for providing the baseline implementation, @msbt.

## Preview

https://sphinx-design-elements--15.org.readthedocs.build/en/15/dropdown-group.html
