### PR TITLE
Fix software tests and update dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
 
     - name: Acquire sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v4

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
 ## v0.2.0 - 2023-08-08
 
 - For dropdown elements that should exclusively open when toggled,
-  add a `dropdown-group` CSS class
+  add a `dropdown-group` CSS class. Thanks, @kojinkai and @msbt.
 
 ## v0.1.0 - 2023-07-19
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,11 +59,11 @@ dependencies = [
 develop = [
   "black<24",
   "docutils-stubs",
-  "mypy==1.4.1",
-  "poethepoet<0.22",
-  "pyproject-fmt<0.14",
-  "ruff==0.0.282",
-  "validate-pyproject<0.14",
+  "mypy==1.5.1",
+  "poethepoet<0.25",
+  "pyproject-fmt<1.2",
+  "ruff==0.0.291",
+  "validate-pyproject<0.15",
 ]
 docs = [
   "furo",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dynamic = [
   "version",
 ]
 dependencies = [
+  "sphinx<7.2",
   "sphinx-design<1",
 ]
 [project.optional-dependencies]


### PR DESCRIPTION
## About

What the title says.

## Details

Downgrading to Sphinx 7.1 was necessary to fix the software tests.

```python
/opt/hostedtoolcache/Python/3.11.5/x64/lib/python3.11/site-packages/sphinx/testing/util.py:105: AttributeError
______________________ test_snippets_myst_post[infocard] _______________________

sphinx_builder = <function sphinx_builder.<locals>._create_project at 0x7faa06375f80>
path = PosixPath('/home/runner/work/sphinx-design-elements/sphinx-design-elements/docs/snippets/myst/infocard.md')
file_regression = <pytest_regressions.file_regression.FileRegressionFixture object at 0x7faa063d16d0>

    @pytest.mark.parametrize(
        "path",
        SNIPPETS_GLOB_MYST,
        ids=[path.name[: -len(path.suffix)] for path in SNIPPETS_GLOB_MYST],
    )
    def test_snippets_myst_post(sphinx_builder: Callable[..., SphinxBuilder], path: Path, file_regression):
        """Test snippets written in MyST Markdown (after HTML post-transforms)."""
>       builder = sphinx_builder()

tests/test_snippets.py:99: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/conftest.py:83: in _create_project
    app = make_app(srcdir=sphinx_path(os.path.abspath(str(src_path))), buildername=buildername)
/opt/hostedtoolcache/Python/3.11.5/x64/lib/python3.11/site-packages/sphinx/testing/fixtures.py:183: in make
    app_: Any = SphinxTestApp(*args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <[AttributeError("'SphinxTestApp' object has no attribute 'builder'") raised in repr()] SphinxTestApp object at 0x7faa063d2f90>
```


```python
         confdir = srcdir
        outdir = builddir.joinpath(buildername)
>       outdir.mkdir(parents=True, exist_ok=True)
E       AttributeError: 'path' object has no attribute 'mkdir'
```

-- https://github.com/panodata/sphinx-design-elements/actions/runs/6372942611/job/17296235252#step:5:1042
